### PR TITLE
Use top-level DurableAgent import from @workflow/ai

### DIFF
--- a/flight-booking-app/workflows/chat/index.ts
+++ b/flight-booking-app/workflows/chat/index.ts
@@ -1,32 +1,32 @@
 import {
-	convertToModelMessages,
-	type UIMessage,
-	type UIMessageChunk,
-} from "ai";
-import { getWritable } from "workflow";
-import { DurableAgent } from "@workflow/ai/agent";
-import { FLIGHT_ASSISTANT_PROMPT, flightBookingTools } from "./steps/tools";
+  convertToModelMessages,
+  type UIMessage,
+  type UIMessageChunk,
+} from 'ai';
+import { getWritable } from 'workflow';
+import { DurableAgent } from '@workflow/ai';
+import { FLIGHT_ASSISTANT_PROMPT, flightBookingTools } from './steps/tools';
 
 /**
  * The main chat workflow
  */
 export async function chat(messages: UIMessage[]) {
-	"use workflow";
+  'use workflow';
 
-	console.log("Starting workflow");
+  console.log('Starting workflow');
 
-	const writable = getWritable<UIMessageChunk>();
+  const writable = getWritable<UIMessageChunk>();
 
-	const agent = new DurableAgent({
-		model: "bedrock/claude-4-sonnet-20250514-v1",
-		system: FLIGHT_ASSISTANT_PROMPT,
-		tools: flightBookingTools,
-	});
+  const agent = new DurableAgent({
+    model: 'bedrock/claude-4-sonnet-20250514-v1',
+    system: FLIGHT_ASSISTANT_PROMPT,
+    tools: flightBookingTools,
+  });
 
-	await agent.stream({
-		messages: convertToModelMessages(messages),
-		writable,
-	});
+  await agent.stream({
+    messages: convertToModelMessages(messages),
+    writable,
+  });
 
-	console.log("Finished workflow");
+  console.log('Finished workflow');
 }

--- a/rag-agent/workflows/chat/index.ts
+++ b/rag-agent/workflows/chat/index.ts
@@ -4,7 +4,7 @@ import {
 	type UIMessageChunk,
 } from "ai";
 import { getWritable } from "workflow";
-import { DurableAgent } from "@workflow/ai/agent";
+import { DurableAgent } from "@workflow/ai";
 import { z } from "zod";
 import { createResource } from "./createResource";
 import { findRelevant } from "./findRelevant";


### PR DESCRIPTION
## Summary
- Update imports to use `@workflow/ai` instead of `@workflow/ai/agent`
- Follows the new preferred import pattern for DurableAgent

## Changes
- `flight-booking-app/workflows/chat/index.ts`: Updated DurableAgent import
- `rag-agent/workflows/chat/index.ts`: Updated DurableAgent import

🤖 Generated with [Claude Code](https://claude.com/claude-code)