### PR TITLE
fix: remove port argument for sveltekit app

### DIFF
--- a/sveltekit/package.json
+++ b/sveltekit/package.json
@@ -4,7 +4,7 @@
 	"version": "0.0.1",
 	"type": "module",
 	"scripts": {
-		"dev": "vite dev --port 3000",
+		"dev": "vite dev",
 		"build": "vite build",
 		"preview": "vite preview",
 		"prepare": "svelte-kit sync || echo ''",


### PR DESCRIPTION
Removes the `--port 3000` argument in the `dev` script of the `package.json` file.

This should be merged when [vercel/workflow #233](https://github.com/vercel/workflow/pull/233) is merged and the release is cut.
