### PR TITLE
fix(postgres): await getWorld() before calling start()

### DIFF
--- a/postgres/instrumentation.ts
+++ b/postgres/instrumentation.ts
@@ -2,6 +2,7 @@
 export async function register() {
   if (process.env.NEXT_RUNTIME !== "edge") {
     const { getWorld } = await import("workflow/runtime");
-    await getWorld().start?.();
+    const world = await getWorld();
+    await world.start?.();
   }
 }


### PR DESCRIPTION
## Summary

`getWorld()` from `workflow/runtime` returns `Promise<World>` after the v2-flow merge — the world singleton became async ([eager-processing changelog: \"Async World Singleton Drift After Merge\"](https://github.com/vercel/workflow/blob/main/docs/content/docs/changelog/eager-processing.mdx)).

`postgres/instrumentation.ts` still calls `.start?.()` on the unresolved Promise, which crashes the production build:

\`\`\`
Type error: Property 'start' does not exist on type 'Promise<World>'.
  3 |   if (process.env.NEXT_RUNTIME !== "edge") {
  4 |     const { getWorld } = await import("workflow/runtime");
> 5 |     await getWorld().start?.();
    |                      ^
\`\`\`

Resolve the promise first, then call `start()` on the resulting world.

## Test plan

- [x] `pnpm build` succeeds with the fix against latest workflow tarballs (`workflow-tarballs-n5b4yau0p.labs.vercel.dev`)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)