### PR TITLE
fix(hono): point start script at .output/server/index.mjs

### DIFF
--- a/hono/package.json
+++ b/hono/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "dev": "nitro dev",
     "build": "nitro build",
-    "start": "node dist/index.js"
+    "start": "node .output/server/index.mjs"
   },
   "dependencies": {
     "@hono/node-server": "^1.19.6",


### PR DESCRIPTION
## Summary

Nitro writes its production server bundle to \`.output/server/index.mjs\`, but the hono example's \`start\` script ran \`node dist/index.js\`:

\`\`\`
> hono@ start /Users/.../hono
> node dist/index.js

Error: Cannot find module '/Users/.../hono/dist/index.js'
  code: 'MODULE_NOT_FOUND'
\`\`\`

Pre-existing — \`pnpm start\` has never worked from this script. Surfaced when smoke-testing the v2-flow tarballs.

## Fix

Point the start script at the path nitro actually emits.

## Test plan

- [x] \`pnpm build\` produces \`.output/server/index.mjs\`
- [x] \`pnpm start\` listens on port 3000
- [x] \`POST /api/signup\` runs the workflow end-to-end (\`Started run wrun_…\`, \`Creating user with email: …\`, \`Sending welcome email to user: …\`)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)